### PR TITLE
using --current option for switching namespace

### DIFF
--- a/k8s_shortcuts
+++ b/k8s_shortcuts
@@ -75,8 +75,7 @@ function kc() {
 
 function kn() {
   if [ ! -z "$1" ]; then
-    x=`k config current-context`
-    k config set-context $x --namespace=$1
+    k config set-context --current --namespace=$1
   fi
   kc
 }


### PR DESCRIPTION
Reference: https://v1-16.docs.kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration
